### PR TITLE
[WIP] profiles: remove obsolete package.accept_keywords entries

### DIFF
--- a/profiles/targets/rpi3/package.accept_keywords/claws-mail
+++ b/profiles/targets/rpi3/package.accept_keywords/claws-mail
@@ -4,5 +4,5 @@ dev-libs/libdbusmenu	* ~*
 net-libs/libetpan	* ~*
 dev-libs/libindicate	* ~*
 x11-themes/sound-theme-freedesktop	* ~*
-net-mail/ytnef  * ~*
+net-mail/ytnef
 

--- a/profiles/targets/rpi3/package.accept_keywords/dav1d
+++ b/profiles/targets/rpi3/package.accept_keywords/dav1d
@@ -1,1 +1,1 @@
-media-libs/dav1d * ~*
+media-libs/dav1d

--- a/profiles/targets/rpi3/package.accept_keywords/eudev
+++ b/profiles/targets/rpi3/package.accept_keywords/eudev
@@ -1,1 +1,1 @@
-sys-fs/eudev * ~*
+sys-fs/eudev

--- a/profiles/targets/rpi3/package.accept_keywords/euses
+++ b/profiles/targets/rpi3/package.accept_keywords/euses
@@ -1,1 +1,1 @@
-app-portage/euses * ~*
+app-portage/euses

--- a/profiles/targets/rpi3/package.accept_keywords/f2fs-tools
+++ b/profiles/targets/rpi3/package.accept_keywords/f2fs-tools
@@ -1,1 +1,1 @@
-sys-fs/f2fs-tools * ~*
+sys-fs/f2fs-tools

--- a/profiles/targets/rpi3/package.accept_keywords/firefox
+++ b/profiles/targets/rpi3/package.accept_keywords/firefox
@@ -1,7 +1,7 @@
-www-client/firefox * ~*
+www-client/firefox
 # required by firefox
-virtual/rust * ~*
+virtual/rust
 dev-util/cargo * ~*
-app-eselect/eselect-rust * ~*
-dev-lang/rust * ~*
-dev-util/cbindgen * ~*
+app-eselect/eselect-rust
+dev-lang/rust
+dev-util/cbindgen

--- a/profiles/targets/rpi3/package.accept_keywords/gimp
+++ b/profiles/targets/rpi3/package.accept_keywords/gimp
@@ -1,8 +1,8 @@
-media-gfx/gimp  * ~*
+media-gfx/gimp
 # requirements of gimp
 
-media-libs/libmypaint   * ~*
-media-libs/gexiv2       * ~*
-media-libs/babl * ~*
-media-libs/gegl * ~*
-media-gfx/mypaint-brushes       * ~*
+media-libs/libmypaint
+media-libs/gexiv2
+media-libs/babl
+media-libs/gegl
+media-gfx/mypaint-brushes

--- a/profiles/targets/rpi3/package.accept_keywords/gtk
+++ b/profiles/targets/rpi3/package.accept_keywords/gtk
@@ -1,2 +1,2 @@
 # required by gtk+ / gtk USE flag on certain packages (e.g. git)
-dev-lang/mujs * ~*
+dev-lang/mujs

--- a/profiles/targets/rpi3/package.accept_keywords/iw
+++ b/profiles/targets/rpi3/package.accept_keywords/iw
@@ -1,1 +1,1 @@
-net-wireless/iw * ~*
+net-wireless/iw

--- a/profiles/targets/rpi3/package.accept_keywords/kodi
+++ b/profiles/targets/rpi3/package.accept_keywords/kodi
@@ -1,7 +1,7 @@
 =media-tv/kodi-18.0* * ~*
 ~media-tv/kodi-18.4 * ~*
 # requirements of media-tv/kodi
-sys-fs/udisks   * ~*
+sys-fs/udisks
 dev-libs/crossguid      * ~*
 dev-libs/libfstrcmp * ~*
 dev-libs/libfmt * ~*

--- a/profiles/targets/rpi3/package.accept_keywords/libreoffice
+++ b/profiles/targets/rpi3/package.accept_keywords/libreoffice
@@ -36,6 +36,6 @@ dev-libs/libixion	* ~*
 app-text/liblangtag	* ~*
 dev-libs/xmlsec	* ~*
 dev-perl/X11-Protocol	* ~*
-app-text/libepubgen * ~*
-app-text/libqxp * ~*
+app-text/libepubgen
+app-text/libqxp
 

--- a/profiles/targets/rpi3/package.accept_keywords/mc
+++ b/profiles/targets/rpi3/package.accept_keywords/mc
@@ -1,1 +1,1 @@
-app-misc/mc * ~*
+app-misc/mc

--- a/profiles/targets/rpi3/package.accept_keywords/mirrorselect
+++ b/profiles/targets/rpi3/package.accept_keywords/mirrorselect
@@ -1,3 +1,3 @@
-app-portage/mirrorselect * ~*
+app-portage/mirrorselect
 # requirements of mirrorselect
-net-analyzer/netselect * ~*
+net-analyzer/netselect

--- a/profiles/targets/rpi3/package.accept_keywords/mupdf
+++ b/profiles/targets/rpi3/package.accept_keywords/mupdf
@@ -1,4 +1,4 @@
-app-text/mupdf * ~*
+app-text/mupdf
 # required by mupdf
-media-libs/glfw * ~*
+media-libs/glfw
 

--- a/profiles/targets/rpi3/package.accept_keywords/nasm
+++ b/profiles/targets/rpi3/package.accept_keywords/nasm
@@ -1,1 +1,1 @@
-dev-lang/nasm * ~*
+dev-lang/nasm

--- a/profiles/targets/rpi3/package.accept_keywords/rng-tools
+++ b/profiles/targets/rpi3/package.accept_keywords/rng-tools
@@ -1,1 +1,1 @@
-sys-apps/rng-tools * ~*
+sys-apps/rng-tools

--- a/profiles/targets/rpi3/package.accept_keywords/thunar-archive-plugin
+++ b/profiles/targets/rpi3/package.accept_keywords/thunar-archive-plugin
@@ -1,5 +1,5 @@
 xfce-extra/thunar-archive-plugin	* ~*
 # requirements of xfce-extra/thunar-archive-plugin
-dev-libs/volume_key     * ~*
-dev-libs/libbytesize    * ~*
-sys-libs/libblockdev    * ~*
+dev-libs/volume_key
+dev-libs/libbytesize
+sys-libs/libblockdev

--- a/profiles/targets/rpi3/package.accept_keywords/thunderbird
+++ b/profiles/targets/rpi3/package.accept_keywords/thunderbird
@@ -1,3 +1,3 @@
 mail-client/thunderbird	* ~*
 # dependencies of thunderbird
-media-plugins/gst-plugins-libav * ~*
+media-plugins/gst-plugins-libav

--- a/profiles/targets/rpi3/package.accept_keywords/v4l-utils
+++ b/profiles/targets/rpi3/package.accept_keywords/v4l-utils
@@ -1,1 +1,1 @@
-media-tv/v4l-utils * ~*
+media-tv/v4l-utils

--- a/profiles/targets/rpi3/package.accept_keywords/virt-manager
+++ b/profiles/targets/rpi3/package.accept_keywords/virt-manager
@@ -1,9 +1,9 @@
 app-emulation/virt-manager * ~*
 # dependencies of virt-manager
-app-emulation/spice-protocol * ~*
-net-libs/gtk-vnc * ~*
-dev-perl/Text-CSV * ~*
+app-emulation/spice-protocol
+net-libs/gtk-vnc
+dev-perl/Text-CSV
 net-misc/x11-ssh-askpass * ~*
-net-misc/spice-gtk * ~*
+net-misc/spice-gtk
 app-emulation/libvirt-glib * ~*
 

--- a/profiles/targets/rpi3/package.accept_keywords/virtual-cron
+++ b/profiles/targets/rpi3/package.accept_keywords/virtual-cron
@@ -1,2 +1,2 @@
-virtual/cron * ~*
+virtual/cron
 

--- a/profiles/targets/rpi3/package.accept_keywords/vlc
+++ b/profiles/targets/rpi3/package.accept_keywords/vlc
@@ -1,5 +1,5 @@
-media-video/vlc * ~*
+media-video/vlc
 # required by vlc
-media-video/ffmpeg * ~*
-media-libs/xvid * ~*
+media-video/ffmpeg
+media-libs/xvid
 media-libs/x264	* ~*

--- a/profiles/targets/rpi3/package.accept_keywords/xf86-input-synaptics
+++ b/profiles/targets/rpi3/package.accept_keywords/xf86-input-synaptics
@@ -1,1 +1,1 @@
-x11-drivers/xf86-input-synaptics * ~*
+x11-drivers/xf86-input-synaptics

--- a/profiles/targets/rpi3/package.accept_keywords/xorg-server
+++ b/profiles/targets/rpi3/package.accept_keywords/xorg-server
@@ -1,2 +1,2 @@
 # get most modern version
-x11-base/xorg-server * ~*
+x11-base/xorg-server


### PR DESCRIPTION
The removed entries are now keyworded for both arm and arm64 in main
Gentoo tree.

Bash script:

    cat profiles/targets/rpi3/package.accept_keywords/* \
    | grep -v -E '^$|^#|^=' \
    | awk '{ print $1 }' \
    | sort -u \
    | while read CATPN; do
          REPO=/usr/portage
          if grep -q 'KEYWORDS=.*arm .*arm64' $REPO/$CATPN/*.ebuild &>/dev/null; then
              echo $CATPN
          fi
      done \
    | while read CATPN; do
          # How the heck to not match anything which just begins with CATPN and has some suffix?
          sed -i -e "\\:^${CATPN}:d" profiles/targets/rpi3/package.accept_keywords/*
      done \
      ;

    find profiles/targets/rpi3/package.accept_keywords/* -empty | xargs git rm -f